### PR TITLE
emit metrics for orphaned env files

### DIFF
--- a/service/collector/collector.go
+++ b/service/collector/collector.go
@@ -1,7 +1,7 @@
 package collector
 
 const (
-	GaugeValue float64 = 1
+	gaugeValue float64 = 1
 	namespace          = "bridge_operator"
 )
 

--- a/service/collector/env.go
+++ b/service/collector/env.go
@@ -17,6 +17,10 @@ const (
 	subsystemEnv = "env"
 )
 
+const (
+	envDirectory = "/run/flannel/networks/"
+)
+
 var (
 	envClusterWithoutFileDesc *prometheus.Desc = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, subsystemEnv, "cluster_without_env_file"),
@@ -39,15 +43,11 @@ var (
 type EnvConfig struct {
 	G8sClient versioned.Interface
 	Logger    micrologger.Logger
-
-	Directory string
 }
 
 type Env struct {
 	g8sClient versioned.Interface
 	logger    micrologger.Logger
-
-	directory string
 }
 
 func NewEnv(config EnvConfig) (*Env, error) {
@@ -58,15 +58,9 @@ func NewEnv(config EnvConfig) (*Env, error) {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
 	}
 
-	if config.Directory == "" {
-		config.Directory = "/run/flannel/networks/"
-	}
-
 	c := &Env{
 		g8sClient: config.G8sClient,
 		logger:    config.Logger,
-
-		directory: config.Directory,
 	}
 
 	return c, nil
@@ -92,7 +86,7 @@ func (c *Env) Collect(ch chan<- prometheus.Metric) error {
 			return nil
 		}
 
-		err := filepath.Walk(c.directory, f)
+		err := filepath.Walk(envDirectory, f)
 		if err != nil {
 			return microerror.Mask(err)
 		}

--- a/service/collector/env.go
+++ b/service/collector/env.go
@@ -88,7 +88,7 @@ func (c *Env) Collect(ch chan<- prometheus.Metric) error {
 		for _, file := range files {
 			id := clusterIDFromPath(file.Name())
 			if id == "" {
-				return microerror.Maskf(invalidFileError, file.Name())
+				return microerror.Maskf(executionFailedError, "file %q does not encode a cluster ID", file.Name())
 			}
 
 			envClusterIDs = append(envClusterIDs, id)

--- a/service/collector/env.go
+++ b/service/collector/env.go
@@ -130,9 +130,9 @@ func (c *Env) Describe(ch chan<- *prometheus.Desc) error {
 	return nil
 }
 
-// clusterIDFromPath received the path variabled from the executed walk
-// function. The path variable is intended to be the file name of the
-// environment file managed by Flannel.
+// clusterIDFromPath receives the file name from the result of ioutil.ReadDir.
+// The path variable is intended to be the file name of the environment file
+// managed by Flannel.
 //
 //     br-ux9ty.env
 //

--- a/service/collector/env.go
+++ b/service/collector/env.go
@@ -22,7 +22,7 @@ const (
 
 var (
 	envClusterWithoutFileDesc *prometheus.Desc = prometheus.NewDesc(
-		prometheus.BuildFQName(namespace, subsystemEnv, "cluster_without_env_file"),
+		prometheus.BuildFQName(namespace, subsystemEnv, "cluster_without_flannel_network_env_file"),
 		"Clusters without environment files.",
 		[]string{
 			labelCluster,
@@ -30,7 +30,7 @@ var (
 		nil,
 	)
 	envFileWithoutClusterDesc *prometheus.Desc = prometheus.NewDesc(
-		prometheus.BuildFQName(namespace, subsystemEnv, "env_file_without_cluster"),
+		prometheus.BuildFQName(namespace, subsystemEnv, "flannel_network_env_file_without_cluster"),
 		"Environment files without associated cluster.",
 		[]string{
 			labelCluster,

--- a/service/collector/env.go
+++ b/service/collector/env.go
@@ -19,7 +19,7 @@ const (
 
 var (
 	envClusterWithoutFileDesc *prometheus.Desc = prometheus.NewDesc(
-		prometheus.BuildFQName(namespace, subsystemEnv, "cluster_without_file"),
+		prometheus.BuildFQName(namespace, subsystemEnv, "cluster_without_env_file"),
 		"Clusters without environment files.",
 		[]string{
 			labelCluster,
@@ -27,7 +27,7 @@ var (
 		nil,
 	)
 	envFileWithoutClusterDesc *prometheus.Desc = prometheus.NewDesc(
-		prometheus.BuildFQName(namespace, subsystemEnv, "file_without_cluster"),
+		prometheus.BuildFQName(namespace, subsystemEnv, "env_file_without_cluster"),
 		"Environment files without associated cluster.",
 		[]string{
 			labelCluster,

--- a/service/collector/env.go
+++ b/service/collector/env.go
@@ -1,7 +1,12 @@
 package collector
 
 import (
+	"os"
+	"path/filepath"
+	"regexp"
+
 	"github.com/prometheus/client_golang/prometheus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
 	"github.com/giantswarm/microerror"
@@ -13,9 +18,17 @@ const (
 )
 
 var (
-	envDesc *prometheus.Desc = prometheus.NewDesc(
-		prometheus.BuildFQName(namespace, subsystemEnv, "inconsistencies"),
-		"Information of environment inconsistencies.",
+	envClusterWithoutFileDesc *prometheus.Desc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, subsystemEnv, "cluster_without_file"),
+		"Clusters without environment files.",
+		[]string{
+			labelCluster,
+		},
+		nil,
+	)
+	envFileWithoutClusterDesc *prometheus.Desc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, subsystemEnv, "file_without_cluster"),
+		"Environment files without associated cluster.",
 		[]string{
 			labelCluster,
 		},
@@ -26,11 +39,15 @@ var (
 type EnvConfig struct {
 	G8sClient versioned.Interface
 	Logger    micrologger.Logger
+
+	Directory string
 }
 
 type Env struct {
 	g8sClient versioned.Interface
 	logger    micrologger.Logger
+
+	directory string
 }
 
 func NewEnv(config EnvConfig) (*Env, error) {
@@ -41,19 +58,130 @@ func NewEnv(config EnvConfig) (*Env, error) {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
 	}
 
-	v := &Env{
-		g8sClient: config.G8sClient,
-		logger:    config.Logger,
+	if config.Directory == "" {
+		config.Directory = "/run/flannel/networks/"
 	}
 
-	return v, nil
+	c := &Env{
+		g8sClient: config.G8sClient,
+		logger:    config.Logger,
+
+		directory: config.Directory,
+	}
+
+	return c, nil
 }
 
-func (v *Env) Collect(ch chan<- prometheus.Metric) error {
+func (c *Env) Collect(ch chan<- prometheus.Metric) error {
+	desiredClusterIDs := map[string]struct{}{}
+	{
+		l, err := c.g8sClient.Core().FlannelConfigs(metav1.NamespaceAll).List(metav1.ListOptions{})
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		for _, i := range l.Items {
+			desiredClusterIDs[i.Name] = struct{}{}
+		}
+	}
+
+	envClusterIDs := map[string]struct{}{}
+	{
+		f := func(path string, info os.FileInfo, err error) error {
+			envClusterIDs[clusterIDFromPath(path)] = struct{}{}
+			return nil
+		}
+
+		err := filepath.Walk(c.directory, f)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	{
+		l, r := symmetricDifference(mapToSlice(desiredClusterIDs), mapToSlice(envClusterIDs))
+
+		// Emit metrics for clusters for which we couldn't find any environment
+		// file.
+		for _, id := range l {
+			//
+		}
+
+		// Emit metrics for environment files for which we couldn't find any
+		// cluster.
+		for _, id := range r {
+			//
+		}
+	}
+
 	return nil
 }
 
-func (v *Env) Describe(ch chan<- *prometheus.Desc) error {
-	ch <- envDesc
+func (c *Env) Describe(ch chan<- *prometheus.Desc) error {
+	ch <- envClusterWithoutFileDesc
+	ch <- envFileWithoutClusterDesc
 	return nil
+}
+
+// clusterIDFromPath received the path variabled from the executed walk
+// function. The path variable is intended to be the file name of the
+// environment file managed by Flannel.
+//
+//     br-ux9ty.env
+//
+func clusterIDFromPath(path string) string {
+	r := regexp.MustCompile(`([a-z0-9]+).env$`)
+	l := r.FindStringSubmatch(path)
+
+	if len(l) == 2 {
+		return l[1]
+	}
+
+	return ""
+}
+
+func containsString(l []string, s string) bool {
+	for _, i := range l {
+		if i == s {
+			return true
+		}
+	}
+
+	return false
+}
+
+func mapToSlice(m map[string]struct{}) []string {
+	var l []string
+
+	for k, _ := range m {
+		l = append(l, k)
+	}
+
+	return l
+}
+
+// symmetricDifference implements the selection of a relative complement of two
+// lists. See also https://en.wikipedia.org/wiki/Set_(mathematics)#Complements.
+// Given input arguments a and b, return value l contains only values that are
+// exclusively in a and r contains only values that are exclusively in b.
+//
+//     a = [1, 2, 3, 4]
+//     b = [3, 4, 5, 6]
+//     l = [1, 2]
+//     r = [5, 6]
+//
+func symmetricDifference(a, b []string) (l []string, r []string) {
+	for _, s := range a {
+		if !containsString(b, s) {
+			l = append(l, s)
+		}
+	}
+
+	for _, s := range b {
+		if !containsString(a, s) {
+			r = append(r, s)
+		}
+	}
+
+	return l, r
 }

--- a/service/collector/env_test.go
+++ b/service/collector/env_test.go
@@ -1,0 +1,120 @@
+package collector
+
+import (
+	"reflect"
+	"strconv"
+	"testing"
+)
+
+func Test_Collector_Env_clusterIDFromPath(t *testing.T) {
+	testCases := []struct {
+		name       string
+		path       string
+		expectedID string
+	}{
+		{
+			name:       "case 0",
+			path:       "br-ux9ty.env",
+			expectedID: "ux9ty",
+		},
+		{
+			name:       "case 1",
+			path:       "br-sdfskdux9ty.env",
+			expectedID: "sdfskdux9ty",
+		},
+		{
+			name:       "case 2",
+			path:       "bridge-ux9ty.env",
+			expectedID: "ux9ty",
+		},
+		{
+			name:       "case 3",
+			path:       "bridge-sdfskdux9ty.env",
+			expectedID: "sdfskdux9ty",
+		},
+		{
+			name:       "case 4",
+			path:       "ux9ty.env",
+			expectedID: "ux9ty",
+		},
+		{
+			name:       "case 5",
+			path:       "sdfskdux9ty.env",
+			expectedID: "sdfskdux9ty",
+		},
+		{
+			name:       "case 6",
+			path:       "sdfskdux9ty",
+			expectedID: "",
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			id := clusterIDFromPath(tc.path)
+
+			if id != tc.expectedID {
+				t.Fatalf("expected %s to equal %s", tc.expectedID, id)
+			}
+		})
+	}
+}
+
+func Test_Collector_Env_symmetricDifference(t *testing.T) {
+	testCases := []struct {
+		name string
+		a    []string
+		b    []string
+		l    []string
+		r    []string
+	}{
+		{
+			name: "case 0",
+			a:    []string{"a", "b", "c", "d"},
+			b:    []string{"c", "d", "e", "f"},
+			l:    []string{"a", "b"},
+			r:    []string{"e", "f"},
+		},
+		{
+			name: "case 1",
+			a:    []string{"a", "b", "c", "d"},
+			b:    []string{"b", "c", "d", "e"},
+			l:    []string{"a"},
+			r:    []string{"e"},
+		},
+		{
+			name: "case 2",
+			a:    []string{"a", "b", "c", "d"},
+			b:    []string{"a", "b", "c", "d", "e"},
+			l:    nil,
+			r:    []string{"e"},
+		},
+		{
+			name: "case 3",
+			a:    []string{"a", "b", "c", "d"},
+			b:    []string{"b", "c", "d"},
+			l:    []string{"a"},
+			r:    nil,
+		},
+		{
+			name: "case 4",
+			a:    []string{"b", "c", "d"},
+			b:    []string{"b", "c", "d"},
+			l:    nil,
+			r:    nil,
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			l, r := symmetricDifference(tc.a, tc.b)
+
+			if !reflect.DeepEqual(l, tc.l) {
+				t.Fatalf("expected %#v to equal %#v", tc.l, l)
+			}
+			if !reflect.DeepEqual(r, tc.r) {
+				t.Fatalf("expected %#v to equal %#v", tc.r, r)
+			}
+		})
+	}
+}

--- a/service/collector/error.go
+++ b/service/collector/error.go
@@ -12,3 +12,12 @@ var invalidConfigError = &microerror.Error{
 func IsInvalidConfig(err error) bool {
 	return microerror.Cause(err) == invalidConfigError
 }
+
+var invalidFileError = &microerror.Error{
+	Kind: "invalidFileError",
+}
+
+// IsInvalidFile asserts invalidFileError.
+func IsInvalidFile(err error) bool {
+	return microerror.Cause(err) == invalidFileError
+}

--- a/service/collector/error.go
+++ b/service/collector/error.go
@@ -4,6 +4,15 @@ import (
 	"github.com/giantswarm/microerror"
 )
 
+var executionFailedError = &microerror.Error{
+	Kind: "executionFailedError",
+}
+
+// IsExecutionFailed asserts executionFailedError.
+func IsExecutionFailed(err error) bool {
+	return microerror.Cause(err) == executionFailedError
+}
+
 var invalidConfigError = &microerror.Error{
 	Kind: "invalidConfigError",
 }
@@ -11,13 +20,4 @@ var invalidConfigError = &microerror.Error{
 // IsInvalidConfig asserts invalidConfigError.
 func IsInvalidConfig(err error) bool {
 	return microerror.Cause(err) == invalidConfigError
-}
-
-var invalidFileError = &microerror.Error{
-	Kind: "invalidFileError",
-}
-
-// IsInvalidFile asserts invalidFileError.
-func IsInvalidFile(err error) bool {
-	return microerror.Cause(err) == invalidFileError
 }


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/5980. As discussed we want to run an operator on each KVM control plane node. That operator only implements metrics collectors for now, without reconciliation. This PR provides the first collector implementation to alert on orphaned env files. Note that the operator is not yet deployed. I need to still sort that out in the next steps. 